### PR TITLE
Update matthew.css resource-link color

### DIFF
--- a/matthew.css
+++ b/matthew.css
@@ -204,12 +204,12 @@ teal - rgb(39,87,90); */
 
 .resource-link {
     text-decoration: none; /* Remove underline */
-    color: #008CBA; /* Choose a distinct color */
+    color: #f0dCa0; /* Choose a distinct color */
 }
 
 .resource-link:hover {
     text-decoration: underline; /* Underline on hover */
-    color: #005f73; /* Darken color on hover */
+    color: #e7c665; /* Darken color on hover */
 }
 
 /*     Matthew CSS Section End    */


### PR DESCRIPTION
Changed resource-link and resource-link:hover text to a soft, golden yellow that contrasts nicely with the cyan sea-green dark teal background